### PR TITLE
Preserve filter state on application list when navigating back to it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
                 "vue-router": "^3.2.0",
                 "vuefire": "^2.2.5",
                 "vuetify": "^2.6.4",
-                "vuex": "^3.4.0"
+                "vuex": "^3.4.0",
+                "vuex-persist": "^3.1.3"
             },
             "devDependencies": {
                 "@braid/vue-formulate": "^2.5.2",
@@ -18249,6 +18250,31 @@
                 "vue": "^2.0.0"
             }
         },
+        "node_modules/vuex-persist": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/vuex-persist/-/vuex-persist-3.1.3.tgz",
+            "integrity": "sha512-QWOpP4SxmJDC5Y1+0+Yl/F4n7z27syd1St/oP+IYCGe0X0GFio0Zan6kngZFufdIhJm+5dFGDo3VG5kdkCGeRQ==",
+            "dependencies": {
+                "deepmerge": "^4.2.2",
+                "flatted": "^3.0.5"
+            },
+            "peerDependencies": {
+                "vuex": ">=2.5"
+            }
+        },
+        "node_modules/vuex-persist/node_modules/deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/vuex-persist/node_modules/flatted": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+            "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+        },
         "node_modules/watchpack": {
             "version": "1.7.5",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
@@ -34294,6 +34320,27 @@
             "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
             "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
             "requires": {}
+        },
+        "vuex-persist": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/vuex-persist/-/vuex-persist-3.1.3.tgz",
+            "integrity": "sha512-QWOpP4SxmJDC5Y1+0+Yl/F4n7z27syd1St/oP+IYCGe0X0GFio0Zan6kngZFufdIhJm+5dFGDo3VG5kdkCGeRQ==",
+            "requires": {
+                "deepmerge": "^4.2.2",
+                "flatted": "^3.0.5"
+            },
+            "dependencies": {
+                "deepmerge": {
+                    "version": "4.2.2",
+                    "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+                    "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+                },
+                "flatted": {
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+                    "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+                }
+            }
         },
         "watchpack": {
             "version": "1.7.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "vue-router": "^3.2.0",
         "vuefire": "^2.2.5",
         "vuetify": "^2.6.4",
-        "vuex": "^3.4.0"
+        "vuex": "^3.4.0",
+        "vuex-persist": "^3.1.3"
     },
     "devDependencies": {
         "@braid/vue-formulate": "^2.5.2",

--- a/src/components/Admin/StudentApplications.vue
+++ b/src/components/Admin/StudentApplications.vue
@@ -130,6 +130,8 @@
               </v-flex>
             </v-row>
           </div>
+
+          <!-- Table where all applications are displayed -->
           <v-data-table
             v-model="selected"
             :headers="headers"

--- a/src/components/Admin/StudentApplications.vue
+++ b/src/components/Admin/StudentApplications.vue
@@ -131,12 +131,12 @@
             </v-row>
           </div>
           <v-data-table
-            :headers="headers"
             v-model="selected"
+            :headers="headers"
             :items="applications"
-            :single-select="false"
-            item-key="test"
+            item-key="uid"
             show-select
+            :single-select="false"
             :search="search"
             :sort="sort"
             class="elevation-1"

--- a/src/components/Admin/StudentApplications.vue
+++ b/src/components/Admin/StudentApplications.vue
@@ -102,24 +102,27 @@
             <v-row>
               <v-flex mx-1>
                 <v-select
-                  :items="semester"
-                  v-model="chosenSemester"
                   label="Semester"
+                  :value="chosenSemester"
+                  @input="setChosenSemester"
+                  :items="semester"
                   multiple
                 ></v-select>
               </v-flex>
               <v-flex mx-1>
                 <v-select
-                  :items="programList"
-                  v-model="program"
                   label="Program"
+                  :value="chosenProgram"
+                  @input="setChosenProgram"
+                  :items="programList"
                   multiple
                 ></v-select>
               </v-flex>
               <v-flex mx-1>
                 <v-select
-                  v-model="status"
                   label="Status"
+                  :value="chosenStatus"
+                  @input="setChosenStatus"
                   :items="statusList"
                   :menu-props="{ maxHeight: '400' }"
                   multiple
@@ -176,6 +179,20 @@ export default {
   components: {
     AdminNavbar
   },
+  computed: {
+    chosenSemester() {
+      return this.$store.state.chosenSemester;
+    },
+    chosenProgram() {
+      return this.$store.state.chosenProgram;
+    },
+    chosenStatus() {
+      return this.$store.state.chosenStatus;
+    },
+    isChosenSemesterEmpty() {
+      return this.$store.getters.isChosenSemesterEmpty;
+    }
+  },
   data() {
     return {
       value: {},
@@ -191,7 +208,6 @@ export default {
       dialog: false,
       applications: [],
       selected: null,
-      chosenSemester: [],
       viewStudentApplications: false,
       positionList: [
         "team lead",
@@ -209,7 +225,6 @@ export default {
         "Internship Application",
         "Justice Media Co-Lab"
       ],
-      program: [],
       statusList: [
         "started",
         "submitted",
@@ -220,7 +235,6 @@ export default {
         "rejcted",
         "declined"
       ],
-      status: [],
       search: "",
       headers: [
         {
@@ -228,7 +242,7 @@ export default {
           value: "firstname"
         },
         {
-          text: "last Name",
+          text: "Last Name",
           value: "lastname"
         },
         {
@@ -243,8 +257,8 @@ export default {
           text: "Program",
           value: "program",
           filter: value => {
-            if (this.program.length == 0) return true;
-            return this.program.includes(value);
+            if (this.chosenProgram.length == 0) return true;
+            return this.chosenProgram.includes(value);
           }
         },
         {
@@ -294,9 +308,9 @@ export default {
           text: "Status",
           value: "status",
           filter: value => {
-            if (this.status.length == 0) return true;
+            if (this.chosenStatus.length == 0) return true;
             if (value) {
-              return this.status.includes(value);
+              return this.chosenStatus.includes(value);
             }
           }
         },
@@ -309,6 +323,18 @@ export default {
     };
   },
   methods: {
+    setChosenSemester(val) {
+      this.$store.commit("setChosenSemester", val);
+      console.log(this.$store.state.chosenSemester);
+    },
+    setChosenProgram(val) {
+      this.$store.commit("setChosenProgram", val);
+      console.log(this.$store.state.chosenProgram);
+    },
+    setChosenStatus(val) {
+      this.$store.commit("setChosenStatus", val);
+      console.log(this.$store.state.chosenStatus);
+    },
     back() {
       this.$router.go(-1);
     },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import Vuex from "vuex";
+import VuexPersistence from "vuex-persist";
 import router from "@/router";
 import { db, auth } from "@/firebase/init.js";
 
@@ -11,6 +12,12 @@ let defaultSetup = (user, context) => {
     context.commit("setAdminValidation", result.claims.admin);
   });
 };
+
+// Persistent storage so state is retained on page reloads!
+const vuexLocal = new VuexPersistence({
+  storage: window.localStorage
+});
+
 export default new Vuex.Store({
   state: {
     user: null,
@@ -18,7 +25,10 @@ export default new Vuex.Store({
     adminValidation: null,
     errorMsg: null,
     snapshot: null,
-    type: null
+    type: null,
+    chosenSemester: [],
+    chosenProgram: [],
+    chosenStatus: []
   },
   mutations: {
     setUser: (state, data) => {
@@ -38,6 +48,15 @@ export default new Vuex.Store({
     },
     setType: (state, data) => {
       state.type = data;
+    },
+    setChosenSemester(state, data) {
+      state.chosenSemester = data;
+    },
+    setChosenProgram(state, data) {
+      state.chosenProgram = data;
+    },
+    setChosenStatus(state, data) {
+      state.chosenStatus = data;
     }
   },
   actions: {
@@ -82,5 +101,6 @@ export default new Vuex.Store({
         .get();
       context.commit("setSnapshot", snap);
     }
-  }
+  },
+  plugins: [vuexLocal.plugin]
 });


### PR DESCRIPTION
## Description

Existing behavior: Navigating back to the student application list in the admin view resets all filters. This is because filters were not kept in a global state store. 
Changes: Added filters to the global state store using Vuex. Now when navigating away from the student applications page and going back, the filters are retained. Also fixed one line of code to make the row selection in the student applications data table work. 

## Related Issues
-  #143 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/rishabnayak/project-engage/issues
[Contributor Guide]: https://github.com/rishabnayak/project-engage/blob/master/CONTRIBUTING.md
