### PR TITLE
add comments to illustrate where the bug is and how we plan to fix it

### DIFF
--- a/src/components/Login/GoogleLoginButton.vue
+++ b/src/components/Login/GoogleLoginButton.vue
@@ -46,6 +46,9 @@ export default {
     }
   },
   methods: {
+    // the bug starts here at the google log in when the view rediected to '/' instead of '/home' right after logging in
+    // a reroute could happen right before the google log in but even with adding a route the google log in still reroutes to '/' instead of '/home'
+    // it seems like theres another place where the google log in happens because even if the function is commented out or not in use, you are still prompted to log in with google
     async googleLogin() {
       var provider = new firebase.auth.GoogleAuthProvider();
       provider.setCustomParameters({
@@ -63,6 +66,9 @@ export default {
     }
   },
   async mounted() {
+    //this function checks the credentials of the user to check if they should be logged in or now
+    // there should be a check where the view changes to /home right before the user logs in and then if the creditials dont match, the user should be redirected to '/'
+    // this should help solve the bug of the double log in and the delayed loading time after logging in
     await auth.getRedirectResult().then(async result => {
       if (result.user != null) {
         await store.dispatch(


### PR DESCRIPTION
## Description

The website has a bug where there is a double login when users log in for the first time and then after the next login, the redirect to /home happens after they see the / page first. Users should automatically be redirected to the /home page without seeing the previous page first after logging.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
  - [ ] I wrote a design doc: *Replace this with a link to your design doc's short link*
  - [ ] I got input from a developer, specifically from: *Replace with the names of who gave advice*
  - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[issue database]: https://github.com/rishabnayak/project-engage/issues
[Contributor Guide]: https://github.com/rishabnayak/project-engage/blob/master/CONTRIBUTING.md
